### PR TITLE
Change category to be the same as most other Map Editor plugins

### DIFF
--- a/info.toml
+++ b/info.toml
@@ -1,7 +1,7 @@
 [meta]
 name = "Editor Trails"
 author = "Miss"
-category = "Editor"
+category = "Map Editor"
 version = "1.0"
 siteid = 251
 


### PR DESCRIPTION
Plugins like editor helpers, map validator, lightmap quality, etc. have the "Map Editor" category instead of the "Editor" category.