### PR TITLE
Add rendering for rotation gizmo and car bounding box

### DIFF
--- a/Settings.as
+++ b/Settings.as
@@ -13,7 +13,17 @@ bool Setting_Follow = false;
 [Setting hidden]
 bool Setting_Events = true;
 
+[Setting hidden]
+bool Setting_DisplayTrails = true;
 
+[Setting hidden]
+bool Setting_DisplayGizmo = true;
+
+[Setting hidden]
+bool Setting_DisplayBox = false;
+
+[Setting hidden]
+bool Setting_DisplayVelocity = true;
 
 [Setting category="General" name="Minimum duration" min=1.0 max=60.0 description="The minimum time in seconds for a trail's instance to be considered valid."]
 double Setting_MinimumDuration = 1.0;
@@ -23,9 +33,6 @@ int Setting_SamplesPerSecond = 10;
 
 [Setting category="General" name="Clear trails on editor play start"]
 bool Setting_ClearOnStart = true;
-
-[Setting category="General" name="Display velocity vector"]
-bool Setting_DisplayVelocity = true;
 
 [Setting category="General" name="Velocity over time" min=0.1 max=2 description="The amount of seconds to use when displaying the velocity over time."]
 float Setting_VelocityOverTime = 1.0f;
@@ -41,6 +48,12 @@ int Setting_TrailWidth = 2;
 [Setting category="Appearance" name="Velocity vector line width" min=1 max=10]
 int Setting_VelocityTrailWidth = 1;
 
+[Setting category="Appearance" name="Box line width" min=1 max=10]
+int Setting_BoxWidth = 1;
+
+[Setting category="Appearance" name="Gizmo line width" min=1 max=10]
+int Setting_GizmoWidth = 1;
+
 [Setting category="Appearance" name="Trail color" color]
 vec4 Setting_TrailColor = vec4(1, 1, 1, 1);
 
@@ -49,6 +62,12 @@ vec4 Setting_CarPositionColor = vec4(1, 0, 0, 1);
 
 [Setting category="Appearance" name="Velocity vector color" color]
 vec4 Setting_CarVelocityColor = vec4(1, 1, 0, 1);
+
+[Setting category="Appearance" name="Car Box color" color]
+vec4 Setting_CarBoxColor = vec4(.9f, .9f, .7f, 1);
+
+[Setting category="Appearance" name="Gizmo scale" min=1.0 max=10.0]
+float Setting_GizmoScale = 2.1f;
 
 [Setting category="Appearance" name="Event scale" min=0.4 max=2.0]
 float Setting_EventScale = 1.0f;

--- a/Trail.as
+++ b/Trail.as
@@ -58,7 +58,29 @@ class Trail
 		Sample newSample;
 		newSample.m_time = State::CurrentRaceTime / 1000.0;
 		newSample.m_position = scriptPlayer.Position;
+#if TMNEXT
+		{
+			vec3 forward = scriptPlayer.AimDirection.Normalized();
+			vec3 up = scriptPlayer.UpDirection.Normalized();
+			vec3 right = Math::Cross(up, forward).Normalized();
+
+			quat q;
+			q.w = Math::Sqrt(1.f + right.x + up.y + forward.z) / 2.f;
+
+			if (Math::Abs(q.w) < 1e-5f) {
+				q = quat(0.f, 0.f, 0.f, 1.f);
+			} else {
+				float t = 1.f / (4.f * q.w);
+				q.x = (up.z - forward.y) * t;
+				q.y = (forward.x - right.z) * t;
+				q.z = (right.y - up.x) * t;
+			}
+
+			newSample.m_dir = q;
+		}
+#else
 		newSample.m_dir = quat(scriptPlayer.AimDirection);
+#endif
 		newSample.m_velocity = velocity;
 		m_samples.InsertLast(newSample);
 	}

--- a/TrailView.as
+++ b/TrailView.as
@@ -72,9 +72,9 @@ namespace TrailView
 			if (MaxTime == -1 || endTime > MaxTime) { MaxTime = endTime; }
 
 			// Render the trail's line
-            if (Setting_DisplayTrails) {
-			    RenderTrailLine(trail);
-            }
+			if (Setting_DisplayTrails) {
+				RenderTrailLine(trail);
+			}
 
 			// Render events on trail
 			if (Setting_Events) {
@@ -195,8 +195,7 @@ namespace TrailView
 			cols[1] = vec4(0, 1, 0, 1);
 			cols[2] = vec4(0, 0, 1, 1);
 
-			for(uint aIdx = 0; aIdx < 3; aIdx++)
-			{
+			for(uint aIdx = 0; aIdx < 3; aIdx++) {
 				vec3 v = sample.m_position + dir * axes[aIdx];
 				vec3 vSS = Camera::ToScreen(v);
 				
@@ -239,16 +238,14 @@ namespace TrailView
 
 			// Draw each face consisting of 4 lines
 			// Overdraws quite a bit. 24 lines instead of 12
-			for(uint fIdx = 0; fIdx < 6; fIdx++)
-			{
+			for(uint fIdx = 0; fIdx < 6; fIdx++) {
 				vec3 v3 = sample.m_position + dir * verts[faces[fIdx][3]];
 				vec3 v3SS = Camera::ToScreen(v3);
 				if (v3SS.z > 0) { continue; }
 
 				nvg::BeginPath();
 				nvg::MoveTo(v3SS.xy);
-				for(uint vIdx = 0; vIdx < 4; vIdx++)
-				{
+				for(uint vIdx = 0; vIdx < 4; vIdx++) {
 					vec3 v = sample.m_position + dir * verts[faces[fIdx][vIdx]];
 					vec3 vSS = Camera::ToScreen(v);
 					if (vSS.z > 0) { continue; }


### PR DESCRIPTION
- Added Rotation Gizmo
- Added Box visually matching the cars bounds
- Moved around some settings, so different visualizations can be toggled from the UI.


![Trackmania_ErtoFygb3n](https://user-images.githubusercontent.com/4254495/222827288-c11fca59-4e53-4e7e-af80-e1d3b5d32bad.png)
![Trackmania_K7NDOhHAtG](https://user-images.githubusercontent.com/4254495/222827290-44a560db-02e1-477a-8a6a-e5892a5c6caa.png)
![Trackmania_1RcjuhrRmD](https://user-images.githubusercontent.com/4254495/222827394-a785bbd3-8b33-481e-8b5e-286364734b66.png)
