### PR TITLE
Add "x" to trails window

### DIFF
--- a/TrailView.as
+++ b/TrailView.as
@@ -184,7 +184,7 @@ namespace TrailView
 	void RenderWindow()
 	{
 		UI::SetNextWindowSize(550, 130, UI::Cond::Appearing);
-		if (UI::Begin(Icons::PlayCircleO + " Editor Trails###EditorTrails")) {
+		if (UI::Begin(Icons::PlayCircleO + " Editor Trails###EditorTrails", Setting_EnableTrails)) {
 			if (Trails::Items.Length == 0) {
 				UI::Text("Enter test mode to record a trail.");
 			} else {


### PR DESCRIPTION
Sorry, the fact there is not a close button on this window has been irking me for some time. I hope this is the right signal to tie it to.
![image](https://user-images.githubusercontent.com/52106022/235535102-c3b867fb-a2d6-42eb-bbcf-82471d0f71c2.png)
