### PR TITLE
Add: Upload to local blender, exports, Checkpoint and Respawn events, basic draw ordering, and details view on hover

### DIFF
--- a/DebugWindow.as
+++ b/DebugWindow.as
@@ -22,6 +22,9 @@ namespace DebugWindow
 			UI::Text("State::InEditorPlay: \\$f39" + tostring(State::InEditorPlay));
 			UI::Text("State::MenuButtonDown: \\$f39" + tostring(State::MenuButtonDown));
 			UI::Text("State::CurrentRaceTime: \\$f39" + tostring(State::CurrentRaceTime));
+			UI::Text("State::DeltaTime: \\$f39" + tostring(State::DeltaTime));
+			UI::Text("g_EventHovered: \\$f39" + tostring(g_EventHovered));
+			UI::Text("g_MouseCoords: \\$f39" + tostring(g_MouseCoords));
 
 			UI::Separator();
 

--- a/DebugWindow.as
+++ b/DebugWindow.as
@@ -10,6 +10,12 @@ namespace DebugWindow
 				Trails::Clear();
 			}
 
+			UI::BeginDisabled(!Setting_EnableUploadTrails);
+			if (UI::Button("Upload Trails to Blender")) {
+				startnew(Upload::OnReenteredEditorAsync);
+			}
+			UI::EndDisabled();
+
 			UI::Separator();
 
 			UI::Text("State::InEditor: \\$f39" + tostring(State::InEditor));

--- a/Event.as
+++ b/Event.as
@@ -2,6 +2,7 @@ class Event : EditorTrails::IEvent
 {
 	double m_time;
 	vec3 m_position;
+	float lastDistanceFromCamera;
 
 	string get_Type() const
 	{

--- a/Event.as
+++ b/Event.as
@@ -6,6 +6,17 @@ class Event
 	string Text() { return "?"; }
 	vec4 Color() { return vec4(1); }
 
+	Json::Value@ ToJson()
+	{
+		auto data = Json::Object();
+		data['t'] = m_time;
+		data['p'] = Json::Array();
+		data['p'].Add(m_position.x);
+		data['p'].Add(m_position.y);
+		data['p'].Add(m_position.z);
+		return data;
+	}
+
 	void Render()
 	{
 		vec3 screenPos = Camera::ToScreen(m_position);

--- a/Event.as
+++ b/Event.as
@@ -45,27 +45,122 @@ class Event : EditorTrails::IEvent
 		pa.x = Math::Round(pa.x);
 		pa.y = Math::Round(pa.y);
 
-		vec2 pb = pa - vec2(0, Math::Round(64 * Setting_EventScale));
+		float stickHeight = Math::Round(64 * Setting_EventScale);
+		vec2 pb = pa - vec2(0, stickHeight);
+		float radius = Math::Round(32 * Setting_EventScale);
+		float radiusSquared = radius * radius;
+		bool hovered = (g_MouseCoords - pb).LengthSquared() < radiusSquared;
+		if (hovered) g_EventHovered = true;
 
 		vec4 color = Color();
 
 		nvg::BeginPath();
-		nvg::Circle(pb, Math::Round(32 * Setting_EventScale));
+		nvg::Circle(pb, radius);
 		nvg::FillColor(color);
 		nvg::Fill();
-
-		nvg::BeginPath();
-		nvg::MoveTo(pb);
-		nvg::LineTo(pa);
-		nvg::StrokeWidth(3);
-		nvg::StrokeColor(color);
+		nvg::StrokeWidth(hovered ? 3 : 0);
+		nvg::StrokeColor(vec4(0, 0, 0, 1));
 		nvg::Stroke();
 
 		nvg::BeginPath();
+		RenderLineSegment(pb, pa, color);
+
+		nvg::BeginPath();
+		RenderText(Text(), pb, 22.0f * Setting_EventScale);
+
+		if (hovered || animProgress > 0) {
+			RenderOnHover(hovered, pa, radius, stickHeight, color);
+		}
+	}
+
+	void RenderText(const string &in text, vec2 pos, float fontSize)
+	{
 		nvg::FontFace(TrailView::FontBold);
-		nvg::FontSize(Math::Round(22 * Setting_EventScale));
+		nvg::FontSize(Math::Round(fontSize));
 		nvg::TextAlign(nvg::Align::Center | nvg::Align::Middle);
 		nvg::FillColor(vec4(0, 0, 0, 1));
-		nvg::Text(pb + vec2(0, 2), Text());
+		nvg::Text(pos + vec2(0, Math::Round(fontSize / 11.0)), text);
+	}
+
+	void RenderLineSegment(vec2 &in from, vec2 &in to, vec4 &in color)
+	{
+		nvg::MoveTo(from);
+		nvg::LineTo(to);
+		nvg::StrokeWidth(3);
+		nvg::StrokeColor(color);
+		nvg::Stroke();
+	}
+
+	float animProgress = 0.0;
+	float lastAnimTime = 0.0;
+	void RenderOnHover(bool hovered, vec2 &in pa, float radius, float stickHeight, vec4 &in color)
+	{
+		auto sign = hovered ? 1.0 : -1.0;
+		animProgress += sign * State::DeltaTime / float(Setting_HoverAnimDuration);
+		animProgress = Math::Clamp(animProgress, 0.0, 1.0);
+		if (animProgress == 0) return;
+		// break progress up into drawing the stick and drawing the
+		auto t1 = Math::Clamp(animProgress * 3.0, 0.0, 1.0);
+		auto t2 = Math::Clamp((animProgress - 0.33333) * 3.0, 0.0, 2.0) / 2.0;
+		RenderHoverDetailsStick(t1, pa, radius, stickHeight, color);
+		RenderHoverDetailsBox(t2, pa, radius, stickHeight, color);
+	}
+
+	void RenderHoverDetailsStick(float t, vec2 &in pa, float radius, float stickHeight, vec4 &in color)
+	{
+		if (t <= 0) return;
+		vec2 pb = pa + vec2(0, stickHeight * t);
+		RenderLineSegment(pa, pb, color);
+	}
+	void RenderHoverDetailsBox(float t, vec2 &in pa, float radius, float stickHeight, vec4 &in color)
+	{
+		if (t <= 0) return;
+
+		if (hoverTextLines.Length == 0)
+			PopulateHoverTextLines();
+
+		auto timeEventScale = t * Setting_EventScale;
+		vec2 size = vec2(196., 128.) * timeEventScale;
+		float fontSize = Math::Round(22. * timeEventScale);
+		float maxTextWidth = CalcMaxTextWidth(fontSize);
+		// add some padding to maxTextWidth
+		size.x = Math::Max(size.x, maxTextWidth + fontSize);
+		vec2 pb = pa + vec2(0, stickHeight);
+		vec2 tl = pb - size / 2.;
+
+		nvg::BeginPath();
+		nvg::RoundedRect(tl, size, radius);
+		nvg::FillColor(color);
+		nvg::Fill();
+		nvg::StrokeWidth(3);
+		nvg::StrokeColor(vec4(0, 0, 0, 1));
+		nvg::Stroke();
+
+		nvg::BeginPath();
+		float nbLines = hoverTextLines.Length;
+		float lineHeight = fontSize * 1.15;
+		float textHeight = lineHeight * nbLines;
+		// offset for text lines
+		vec2 pc = pb - vec2(0, (textHeight - fontSize) / 2.);
+		for (uint i = 0; i < hoverTextLines.Length; i++) {
+			RenderText(hoverTextLines[i], pc, fontSize);
+			pc += vec2(0, lineHeight);
+		}
+	}
+
+	string[] hoverTextLines;
+	void PopulateHoverTextLines() {
+		if (hoverTextLines.Length > 0) return;
+		hoverTextLines.InsertLast("Generic Event");
+		hoverTextLines.InsertLast("Overload PopulateHoverTextLines");
+	}
+
+	float CalcMaxTextWidth(float fontSize) {
+		nvg::FontSize(fontSize);
+		float max = 0.;
+		for (uint i = 0; i < hoverTextLines.Length; i++) {
+			max = Math::Max(max, nvg::TextBounds(hoverTextLines[i]).x);
+		}
+		return max;
 	}
 }

--- a/Event.as
+++ b/Event.as
@@ -2,7 +2,7 @@ class Event : EditorTrails::IEvent
 {
 	double m_time;
 	vec3 m_position;
-	float lastDistanceFromCamera;
+	float lastDistanceSqFromCamera = 0.0;
 
 	string get_Type() const
 	{
@@ -40,6 +40,7 @@ class Event : EditorTrails::IEvent
 			return;
 		}
 
+		lastDistanceSqFromCamera = (Camera::GetCurrentPosition() - m_position).LengthSquared();
 		vec2 pa = screenPos.xy;
 		pa.x = Math::Round(pa.x);
 		pa.y = Math::Round(pa.y);

--- a/Event.as
+++ b/Event.as
@@ -1,12 +1,17 @@
-class Event
+class Event : EditorTrails::IEvent
 {
 	double m_time;
 	vec3 m_position;
 
-	string Text() { return "?"; }
-	vec4 Color() { return vec4(1); }
+	string get_Type() const
+	{
+		return "Generic";
+	}
 
-	Json::Value@ ToJson()
+	string Text() const { return "?"; }
+	vec4 Color() const { return vec4(1); }
+
+	Json::Value@ ToJson() const
 	{
 		auto data = Json::Object();
 		data['t'] = m_time;
@@ -15,6 +20,16 @@ class Event
 		data['p'].Add(m_position.y);
 		data['p'].Add(m_position.z);
 		return data;
+	}
+
+	double get_Time() const
+	{
+		return m_time;
+	}
+
+	vec3 get_Position() const
+	{
+		return m_position;
 	}
 
 	void Render()

--- a/Events/Checkpoint.as
+++ b/Events/Checkpoint.as
@@ -62,9 +62,9 @@ namespace Events
 		void PopulateHoverTextLines() override
 		{
 			if (hoverTextLines.Length > 0) return;
-			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast(Time::Format(m_time * 1000.));
 			hoverTextLines.InsertLast("No Respawn: " + Time::Format(m_noRespawnTime));
-			hoverTextLines.InsertLast("Nb Respawns: " + Time::Format(m_respawns));
+			hoverTextLines.InsertLast("Nb Respawns: " + m_respawns);
 		}
 	}
 }

--- a/Events/Checkpoint.as
+++ b/Events/Checkpoint.as
@@ -1,0 +1,62 @@
+namespace Events
+{
+	class Checkpoint : Event
+	{
+        int m_number;
+        int m_respawns;
+        int m_noRespawnTime;
+        bool m_isEndLap = false;
+        bool m_isFinish = false;
+        int m_lapTime;
+        int m_lapEndNb;
+
+
+		string get_Type() const override
+		{
+			return "Checkpoint";
+		}
+
+		string Text() const override
+		{
+            if (m_isFinish)
+				return Icons::Trophy;
+			if (m_isEndLap)
+				return "Lap " + m_lapEndNb;
+			return Icons::ClockO;
+		}
+
+		Json::Value@ ToJson() const override
+		{
+			auto data = Event::ToJson();
+			auto inner = Json::Object();
+
+			inner['respawns'] = m_respawns;
+			inner['noRespawnTime'] = m_noRespawnTime;
+
+			if (m_isFinish || m_isEndLap) {
+				inner['lapTime'] = m_lapTime;
+				inner['lapNumber'] = m_lapEndNb;
+			}
+
+			if (m_isFinish)
+				data['finish'] = inner;
+			else if (m_isEndLap)
+				data['lap'] = inner;
+			else
+				data['cp'] = inner;
+			return data;
+		}
+
+		vec4 Color() const override
+		{
+            if (m_isFinish)
+                // gold
+			    return vec4(0.95f, 0.73f, 0, 1);
+            if (m_isEndLap)
+                // silver
+			    return vec4(0.655f, 0.665f, 0.68f, 1);
+            // checkpoint, pale green
+            return vec4(0.6f, 0.98f, 0.6f, 1);
+		}
+	}
+}

--- a/Events/Checkpoint.as
+++ b/Events/Checkpoint.as
@@ -22,7 +22,7 @@ namespace Events
 				return Icons::Trophy;
 			if (m_isEndLap)
 				return "Lap " + m_lapEndNb;
-			return Icons::ClockO;
+			return Icons::ClockO + " " + m_number;
 		}
 
 		Json::Value@ ToJson() const override
@@ -56,7 +56,15 @@ namespace Events
                 // silver
 			    return vec4(0.655f, 0.665f, 0.68f, 1);
             // checkpoint, pale green
-            return vec4(0.6f, 0.98f, 0.6f, 1);
+            return vec4(0.25f, 0.98f, 0.25f, 1);
+		}
+
+		void PopulateHoverTextLines() override
+		{
+			if (hoverTextLines.Length > 0) return;
+			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast("No Respawn: " + Time::Format(m_noRespawnTime));
+			hoverTextLines.InsertLast("Nb Respawns: " + Time::Format(m_respawns));
 		}
 	}
 }

--- a/Events/GearChange.as
+++ b/Events/GearChange.as
@@ -32,5 +32,12 @@ namespace Events
 				return vec4(1, 0.5f, 0.5f, 1);
 			}
 		}
+
+		void PopulateHoverTextLines() override
+		{
+			if (hoverTextLines.Length > 0) return;
+			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast("Gear " + m_prev + Icons::ArrowRight + m_new);
+		}
 	}
 }

--- a/Events/GearChange.as
+++ b/Events/GearChange.as
@@ -5,12 +5,17 @@ namespace Events
 		int m_prev;
 		int m_new;
 
-		string Text() override
+		string get_Type() const override
+		{
+			return "GearChange";
+		}
+
+		string Text() const override
 		{
 			return Icons::Cog + " " + tostring(m_new);
 		}
 
-		Json::Value@ ToJson() override
+		Json::Value@ ToJson() const override
 		{
 			auto data = Event::ToJson();
 			data['gear'] = Json::Object();
@@ -19,7 +24,7 @@ namespace Events
 			return data;
 		}
 
-		vec4 Color() override
+		vec4 Color() const override
 		{
 			if (m_new > m_prev) {
 				return vec4(0.5f, 1, 0.5f, 1);

--- a/Events/GearChange.as
+++ b/Events/GearChange.as
@@ -36,7 +36,7 @@ namespace Events
 		void PopulateHoverTextLines() override
 		{
 			if (hoverTextLines.Length > 0) return;
-			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast(Time::Format(m_time * 1000.));
 			hoverTextLines.InsertLast("Gear " + m_prev + Icons::ArrowRight + m_new);
 		}
 	}

--- a/Events/GearChange.as
+++ b/Events/GearChange.as
@@ -10,6 +10,15 @@ namespace Events
 			return Icons::Cog + " " + tostring(m_new);
 		}
 
+		Json::Value@ ToJson() override
+		{
+			auto data = Event::ToJson();
+			data['gear'] = Json::Object();
+			data['gear']['prev'] = m_prev;
+			data['gear']['new'] = m_new;
+			return data;
+		}
+
 		vec4 Color() override
 		{
 			if (m_new > m_prev) {

--- a/Events/Respawn.as
+++ b/Events/Respawn.as
@@ -31,5 +31,13 @@ namespace Events
 				return vec4(0.55f, 0.82f, 1, 1);
 			}
 		}
+
+		void PopulateHoverTextLines() override
+		{
+			if (hoverTextLines.Length > 0) return;
+			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast("Respawn " + m_number);
+			if (m_standing) hoverTextLines.InsertLast("Standing Respawn");
+		}
 	}
 }

--- a/Events/Respawn.as
+++ b/Events/Respawn.as
@@ -35,7 +35,7 @@ namespace Events
 		void PopulateHoverTextLines() override
 		{
 			if (hoverTextLines.Length > 0) return;
-			hoverTextLines.InsertLast(Time::Format(m_time));
+			hoverTextLines.InsertLast(Time::Format(m_time * 1000.));
 			hoverTextLines.InsertLast("Respawn " + m_number);
 			if (m_standing) hoverTextLines.InsertLast("Standing Respawn");
 		}

--- a/Events/Respawn.as
+++ b/Events/Respawn.as
@@ -1,0 +1,35 @@
+namespace Events
+{
+	class Respawn : Event
+	{
+        bool m_standing = false;
+        int m_number;
+
+		string get_Type() const override
+		{
+			return "Respawn";
+		}
+
+		string Text() const override
+		{
+			return Icons::Undo + " " + tostring(m_number);
+		}
+
+		Json::Value@ ToJson() const override
+		{
+			auto data = Event::ToJson();
+			data['respawn'] = Json::Object();
+			data['respawn']['standing'] = m_standing;
+			return data;
+		}
+
+		vec4 Color() const override
+		{
+			if (m_standing) {
+				return vec4(0.2f, 0.2f, 0.8f, 1);
+			} else {
+				return vec4(0.55f, 0.82f, 1, 1);
+			}
+		}
+	}
+}

--- a/Export_Shared.as
+++ b/Export_Shared.as
@@ -1,6 +1,32 @@
-namespace EditorTrails {
-    interface ITrail {
-        const array<Sample>@ GetSamples() const;
-        const array<Sample>@ GetEvents() const;
+namespace EditorTrails
+{
+    interface ITrail
+    {
+        // Note: ITrail::get_Samples must return an array of handles, otherwise we get:
+        // > ERR : The subtype has no default factory
+
+        // The vehicle samples in the trail.
+        const array<ISample@>@ get_Samples() const;
+        const array<IEvent@>@ get_Events() const;
+	    double get_Duration() const;
+        string ToJsonString() const;
+    }
+
+    interface ISample
+    {
+        Json::Value@ ToJson() const;
+        double get_Time() const;
+        vec3 get_Position() const;
+        vec3 get_Velocity() const;
+        quat get_Dir() const;
+    }
+
+    interface IEvent
+    {
+        Json::Value@ ToJson() const;
+        double get_Time() const;
+        vec3 get_Position() const;
+        string Text() const;
+        void Render();
     }
 }

--- a/Export_Shared.as
+++ b/Export_Shared.as
@@ -1,0 +1,6 @@
+namespace EditorTrails {
+    interface ITrail {
+        const array<Sample>@ GetSamples() const;
+        const array<Sample>@ GetEvents() const;
+    }
+}

--- a/Exports.as
+++ b/Exports.as
@@ -1,0 +1,3 @@
+namespace EditorTrials {
+    import array<ITrail@>@ GetTrails() from "EditorTrials";
+}

--- a/Exports.as
+++ b/Exports.as
@@ -1,3 +1,4 @@
-namespace EditorTrials {
-    import array<ITrail@>@ GetTrails() from "EditorTrials";
+namespace EditorTrails
+{
+    import array<ITrail@>@ GetTrails() from "EditorTrails";
 }

--- a/ExportsImpl.as
+++ b/ExportsImpl.as
@@ -1,0 +1,5 @@
+namespace EditorTrials {
+    array<ITrail@>@ GetTrails() {
+        return Trails::Items;
+    }
+}

--- a/ExportsImpl.as
+++ b/ExportsImpl.as
@@ -1,5 +1,7 @@
-namespace EditorTrials {
-    array<ITrail@>@ GetTrails() {
-        return Trails::Items;
+namespace EditorTrails
+{
+    array<ITrail@>@ GetTrails()
+    {
+        return Trails::ItemsForExport;
     }
 }

--- a/Sample.as
+++ b/Sample.as
@@ -14,4 +14,24 @@ class Sample
 		ret.m_velocity = Math::Lerp(m_velocity, other.m_velocity, factor);
 		return ret;
 	}
+
+	Json::Value@ ToJson()
+	{
+		auto data = Json::Object();
+		data['t'] = m_time;
+		data['p'] = Json::Array();
+		data['p'].Add(m_position.x);
+		data['p'].Add(m_position.y);
+		data['p'].Add(m_position.z);
+		data['q'] = Json::Array();
+		data['q'].Add(m_dir.x);
+		data['q'].Add(m_dir.y);
+		data['q'].Add(m_dir.z);
+		data['q'].Add(m_dir.w);
+		data['v'] = Json::Array();
+		data['v'].Add(m_velocity.x);
+		data['v'].Add(m_velocity.y);
+		data['v'].Add(m_velocity.z);
+		return data;
+	}
 }

--- a/Sample.as
+++ b/Sample.as
@@ -1,4 +1,4 @@
-class Sample
+class Sample : EditorTrails::ISample
 {
 	double m_time;
 	vec3 m_position;
@@ -15,7 +15,7 @@ class Sample
 		return ret;
 	}
 
-	Json::Value@ ToJson()
+	Json::Value@ ToJson() const
 	{
 		auto data = Json::Object();
 		data['t'] = m_time;
@@ -33,5 +33,25 @@ class Sample
 		data['v'].Add(m_velocity.y);
 		data['v'].Add(m_velocity.z);
 		return data;
+	}
+
+	double get_Time() const
+	{
+		return m_time;
+	}
+
+	vec3 get_Position() const
+	{
+		return m_position;
+	}
+
+	vec3 get_Velocity() const
+	{
+		return m_velocity;
+	}
+
+	quat get_Dir() const
+	{
+		return m_dir;
 	}
 }

--- a/Sample.as
+++ b/Sample.as
@@ -4,6 +4,7 @@ class Sample : EditorTrails::ISample
 	vec3 m_position;
 	quat m_dir;
 	vec3 m_velocity;
+	bool m_didRespawn;
 
 	Sample Interpolate(const Sample &in other, float factor)
 	{
@@ -32,6 +33,9 @@ class Sample : EditorTrails::ISample
 		data['v'].Add(m_velocity.x);
 		data['v'].Add(m_velocity.y);
 		data['v'].Add(m_velocity.z);
+		if (m_didRespawn) {
+			data['respawn'] = m_didRespawn;
+		}
 		return data;
 	}
 

--- a/Settings.as
+++ b/Settings.as
@@ -52,3 +52,9 @@ vec4 Setting_CarVelocityColor = vec4(1, 1, 0, 1);
 
 [Setting category="Appearance" name="Event scale" min=0.4 max=2.0]
 float Setting_EventScale = 1.0f;
+
+[Setting category="Blender Integration" name="Enable" description="Upon reentering the editor, send the recorded trails to blender via an HTTP POST."]
+bool Setting_EnableUploadTrails = false;
+
+[Setting category="Blender Integration" name="POST URL" description="The full URL (including port) that the trails will be POSTed to."]
+string Setting_UploadTrailsURL = "http://localhost:42069/trails";

--- a/Settings.as
+++ b/Settings.as
@@ -53,6 +53,11 @@ vec4 Setting_CarVelocityColor = vec4(1, 1, 0, 1);
 [Setting category="Appearance" name="Event scale" min=0.4 max=2.0]
 float Setting_EventScale = 1.0f;
 
+[Setting category="Appearance" name="Hover animation duration" min=0 max=1000]
+uint Setting_HoverAnimDuration = 150;
+
+
+
 [Setting category="Blender Integration" name="Enable" description="Upon reentering the editor, send the recorded trails to blender via an HTTP POST."]
 bool Setting_EnableUploadTrails = false;
 

--- a/Trail.as
+++ b/Trail.as
@@ -3,6 +3,7 @@ class Trail : EditorTrails::ITrail
 	array<Sample> m_samples;
 	array<EditorTrails::ISample@> m_samplesHandles;
 	array<EditorTrails::IEvent@> m_events;
+	uint[] m_eventsRenderOrder;
 
 	TrailPlayer@ m_player; //TODO: Do we need this here? It's a circular reference!
 
@@ -19,8 +20,12 @@ class Trail : EditorTrails::ITrail
 		m_samples.Reserve(1000);
 		m_samplesHandles.Reserve(1000);
 		m_events.Reserve(25);
-
 		@m_player = TrailPlayer(this);
+	}
+
+	void AddEvent(EditorTrails::IEvent@ event) {
+		m_eventsRenderOrder.InsertLast(m_events.Length);
+		m_events.InsertLast(event);
 	}
 
 #if TMNEXT
@@ -90,7 +95,7 @@ class Trail : EditorTrails::ITrail
 			newGearChangeEvent.m_position = scriptPlayer.Position;
 			newGearChangeEvent.m_prev = m_lastGear;
 			newGearChangeEvent.m_new = gear;
-			m_events.InsertLast(newGearChangeEvent);
+			AddEvent(newGearChangeEvent);
 
 			// Remember our last gear
 			m_lastGear = scriptPlayer.EngineCurGear;
@@ -119,7 +124,7 @@ class Trail : EditorTrails::ITrail
 			newRespawnEvent.m_position = m_lastPosition;
 			newRespawnEvent.m_time = player.LastRespawnRaceTime;
 			newRespawnEvent.m_number = player.NbRespawnsRequested;
-			m_events.InsertLast(newRespawnEvent);
+			AddEvent(newRespawnEvent);
 			m_didRespawn = true;
 		}
 
@@ -146,7 +151,7 @@ class Trail : EditorTrails::ITrail
 				m_hasFinished = true;
 				newCheckpointEvent.m_isFinish = true;
 			}
-			m_events.InsertLast(newCheckpointEvent);
+			AddEvent(newCheckpointEvent);
 		}
 #endif
 	}

--- a/Trail.as
+++ b/Trail.as
@@ -122,7 +122,7 @@ class Trail : EditorTrails::ITrail
 			Events::Respawn@ newRespawnEvent = Events::Respawn();
 			newRespawnEvent.m_standing = Camera::GetCurrent().Vel.LengthSquared() <= 0.0001;
 			newRespawnEvent.m_position = m_lastPosition;
-			newRespawnEvent.m_time = player.LastRespawnRaceTime;
+			newRespawnEvent.m_time = double(player.LastRespawnRaceTime) / 1000.0;
 			newRespawnEvent.m_number = player.NbRespawnsRequested;
 			AddEvent(newRespawnEvent);
 			m_didRespawn = true;
@@ -131,7 +131,7 @@ class Trail : EditorTrails::ITrail
 		if (m_lastCp != player.CpCount) {
 			m_lastCp = player.CpCount;
 			Events::Checkpoint@ newCheckpointEvent = Events::Checkpoint();
-			newCheckpointEvent.m_time = player.LastCpTime;
+			newCheckpointEvent.m_time = double(player.LastCpTime) / 1000.0;
 			newCheckpointEvent.m_position = m_lastPosition;
 			newCheckpointEvent.m_respawns = player.NbRespawnsRequested;
 			newCheckpointEvent.m_noRespawnTime = player.LastTheoreticalCpTime;

--- a/TrailView.as
+++ b/TrailView.as
@@ -141,6 +141,8 @@ namespace TrailView
 			vec3 pb = Camera::ToScreen(trail.m_samples[i + 1].m_position);
 			if (pb.z > 0) {
 				firstPoint = true;
+			} else if (trail.m_samples[i + 1].m_didRespawn) {
+				nvg::MoveTo(pb.xy);
 			} else {
 				nvg::LineTo(pb.xy);
 			}

--- a/TrailView.as
+++ b/TrailView.as
@@ -154,8 +154,20 @@ namespace TrailView
 
 	void RenderTrailEvents(Trail@ trail)
 	{
-		for (uint i = 0; i < trail.m_events.Length; i++) {
-			trail.m_events[i].Render();
+		if (trail.m_events.Length == 0) return;
+		auto ix = trail.m_eventsRenderOrder[0];
+		trail.m_events[ix].Render();
+		auto lastCameraDist = cast<Event>(trail.m_events[ix]).lastDistanceSqFromCamera;
+		float myCameraDist;
+		for (uint i = 1; i < trail.m_events.Length; i++) {
+			ix = trail.m_eventsRenderOrder[i];
+			trail.m_events[ix].Render();
+			myCameraDist = cast<Event>(trail.m_events[ix]).lastDistanceSqFromCamera;
+			if (myCameraDist > lastCameraDist) {
+				trail.m_eventsRenderOrder[i] = trail.m_eventsRenderOrder[i - 1];
+				trail.m_eventsRenderOrder[i - 1] = ix;
+			}
+			lastCameraDist = myCameraDist;
 		}
 	}
 

--- a/TrailView.as
+++ b/TrailView.as
@@ -1,3 +1,6 @@
+bool g_EventHovered = false;
+vec2 g_MouseCoords;
+
 namespace TrailView
 {
 	int FontBold;
@@ -61,6 +64,8 @@ namespace TrailView
 		double sumY = 0;
 		double sumZ = 0;
 		int numPos = 0;
+		g_EventHovered = false;
+		g_MouseCoords = UI::GetMousePos();
 
 		for (uint i = 0; i < Trails::Items.Length; i++) {
 			auto trail = Trails::Items[i];

--- a/Trails.as
+++ b/Trails.as
@@ -1,11 +1,13 @@
 namespace Trails
 {
 	array<Trail@> Items;
+	array<EditorTrails::ITrail@> ItemsForExport;
 
 	Trail@ CreateNew()
 	{
 		Trail@ newTrail = Trail();
 		Items.InsertLast(newTrail);
+		ItemsForExport.InsertLast(newTrail);
 		return newTrail;
 	}
 
@@ -28,5 +30,6 @@ namespace Trails
 	void Clear()
 	{
 		Items.RemoveRange(0, Items.Length);
+		ItemsForExport.RemoveRange(0, ItemsForExport.Length);
 	}
 }

--- a/UploadTrails.as
+++ b/UploadTrails.as
@@ -1,0 +1,41 @@
+namespace Upload {
+	void OnReenteredEditorAsync()
+	{
+		if (!Setting_EnableUploadTrails) return;
+		trace('Serializing trails for upload');
+		array<Trail@>@ trails = Trails::Items;
+		auto postdata = GenerateUploadJson(trails);
+		trace('Generated postdata for upload; length: ' + postdata.Length);
+		RunUpload(postdata);
+	}
+
+	string GenerateUploadJson(Trail@[]@ trails)
+	{
+		string data = '[';
+		uint lastYield = Time::Now;
+		for (uint i = 0; i < trails.Length; i++) {
+			data += (i > 0 ? ", " : "") + trails[i].ToJsonString();
+			// avoid doing more than 5ms of processing at one time
+			if (Time::Now - lastYield > 5) {
+				yield();
+				lastYield = Time::Now;
+			}
+		}
+		return data + ']';
+	}
+
+	void RunUpload(const string &in data)
+	{
+		trace("Uploading editor trails to " + Setting_UploadTrailsURL);
+		auto request = Net::HttpPost(Setting_UploadTrailsURL, data, "application/json");
+		while (!request.Finished()) yield();
+		auto status = request.ResponseCode();
+		if (200 <= status && status < 300) {
+			trace("Uploading editor trails succeeded.");
+			return;
+		}
+		string msg = "Uploading editor trails to URL failed! Status code: " + status + ". Response body: `" + request.String() + "`.";
+		warn(msg);
+		UI::ShowNotification(Meta::ExecutingPlugin().Name, msg, vec4(.7, .2, .2, .7));
+	}
+}

--- a/info.toml
+++ b/info.toml
@@ -7,3 +7,4 @@ siteid = 251
 
 [script]
 dependencies = [ "Camera" ]
+exports = ["Exports.as"]

--- a/info.toml
+++ b/info.toml
@@ -7,4 +7,5 @@ siteid = 251
 
 [script]
 dependencies = [ "Camera" ]
+optional_dependencies = [ "MLHook", "MLFeedRaceData" ]
 exports = [ "Exports.as" ]

--- a/info.toml
+++ b/info.toml
@@ -1,5 +1,5 @@
 [meta]
-name = "Editor Trails"
+name = "Editor Trails (Dev)"
 author = "Miss"
 category = "Map Editor"
 version = "1.1"
@@ -7,4 +7,4 @@ siteid = 251
 
 [script]
 dependencies = [ "Camera" ]
-exports = ["Exports.as"]
+exports = [ "Exports.as" ]

--- a/main.as
+++ b/main.as
@@ -5,6 +5,8 @@ namespace State
 	bool MenuButtonDown = false;
 
 	int CurrentRaceTime = 0;
+
+	float DeltaTime = 10.;
 }
 
 void OnEditorLeave()
@@ -208,6 +210,7 @@ void Main()
 void Update(float dt)
 {
 	if (State::InEditor && !State::InEditorPlay) {
+		State::DeltaTime = dt;
 		// Update trail view
 		TrailView::Update(dt);
 	}

--- a/main.as
+++ b/main.as
@@ -37,6 +37,10 @@ void OnEditorPlayLeave()
 		}
 	}
 
+	// Upload trails to blender if the setting is enabled
+	trace("DEBUG calling Upload::OnReenteredEditorAsync");
+	startnew(Upload::OnReenteredEditorAsync);
+
 	// Reset trail view
 	TrailView::Reset();
 }


### PR DESCRIPTION
See images / video on discord: https://discord.com/channels/276076890714800129/1066773082695553136/1161446693892526191
(Note, some of the bugs in those videos are now fixed)

Note that this PR adds MLHook and MLFeed as optional dependencies.

Features:
- Upload trails data to blender server when returning to the editor
  - sub-feature: json export
- Add exports for other plugins (exports Trails::Items)
- CP & Respawn events (will try to hide the next line segment after a respawn to avoid the ugly lines)
- Draw ordering: each frame the events that are drawn check to see if they are in front of the prior-drawn event. If so, the draw indexes get swapped. This results in eventual ordering, and after that it's pretty quick to reorder as you drag around the camera.
- A hover card that pops up with a little animation + details text for each event.

Current bugs:
- Hover detail cards don't show on top of everything else (so closer events will draw on top of them)
- Respawns sometimes (rarely) seem to trigger a frame early or something -- not sure I understand why
- Standing respawn detection is a bit hacky but seems to mostly work, some false positives