### PR TITLE
Fix current time and Add support for Editor++ 3d Trails

### DIFF
--- a/3dTrails.as
+++ b/3dTrails.as
@@ -1,0 +1,81 @@
+namespace EppState {
+    int lastTrailsCount = 0;
+    int[] lastTrailSampleCounts;
+    bool trailsChanged = false;
+    bool resetDrawInstance = true;
+
+    void BeforeDraw()
+    {
+        if (!ShouldUseEditorPlusPlus()) return;
+        trailsChanged = false;
+        if (lastTrailsCount != Trails::Items.Length) {
+            lastTrailsCount = Trails::Items.Length;
+            trailsChanged = true;
+        }
+        lastTrailSampleCounts.Resize(lastTrailsCount);
+        for (int i = 0; i < lastTrailsCount; i++) {
+            auto count = Trails::Items[i].m_samples.Length;
+            if (lastTrailSampleCounts[i] != count) {
+                lastTrailSampleCounts[i] = count;
+                trailsChanged = true;
+            }
+        }
+        resetDrawInstance = trailsChanged;
+    }
+}
+
+
+#if DEPENDENCY_EDITOR
+
+void ResetEppTrails()
+{
+    auto di = Editor::DrawLinesAndQuads::GetOrCreateDrawInstance("editor-trails");
+    di.Reset();
+}
+
+bool ShouldUseEditorPlusPlus()
+{
+    auto epp = Meta::GetPluginFromID("Editor");
+    if (epp is null) {
+        return false;
+    }
+    return epp.Enabled;
+}
+
+void RenderTrailLineEpp(Trail@ trail)
+{
+    auto di = Editor::DrawLinesAndQuads::GetOrCreateDrawInstance("editor-trails");
+    di.Draw();
+    if (!EppState::trailsChanged) return;
+    if (EppState::resetDrawInstance) {
+        di.Reset();
+        EppState::resetDrawInstance = false;
+    }
+    vec3[] path;
+    for (uint j = 0; j < trail.m_samples.Length; j++) {
+        path.InsertLast(trail.m_samples[j].m_position + vec3(0, 64.25, 0));
+    }
+    di.PushLineSegmentsFromPath(path);
+    di.RequestLineColor(Setting_TrailColor.xyz);
+}
+
+
+#else
+
+
+void ResetEppTrails()
+{
+}
+
+bool ShouldUseEditorPlusPlus()
+{
+    return false;
+}
+
+void RenderTrailLineEpp(Trail@ trail)
+{
+    throw("Should never be called");
+}
+
+
+#endif

--- a/TrailView.as
+++ b/TrailView.as
@@ -62,6 +62,8 @@ namespace TrailView
 		double sumZ = 0;
 		int numPos = 0;
 
+		EppState::BeforeDraw();
+
 		for (uint i = 0; i < Trails::Items.Length; i++) {
 			auto trail = Trails::Items[i];
 
@@ -122,6 +124,16 @@ namespace TrailView
 	}
 
 	void RenderTrailLine(Trail@ trail)
+	{
+		if (ShouldUseEditorPlusPlus()) {
+			RenderTrailLineEpp(trail);
+		} else {
+			RenderTrailLineNvg(trail);
+		}
+	}
+
+
+	void RenderTrailLineNvg(Trail@ trail)
 	{
 		nvg::BeginPath();
 		bool firstPoint = true;

--- a/Trails.as
+++ b/Trails.as
@@ -28,5 +28,6 @@ namespace Trails
 	void Clear()
 	{
 		Items.RemoveRange(0, Items.Length);
+		ResetEppTrails();
 	}
 }

--- a/info.toml
+++ b/info.toml
@@ -7,3 +7,4 @@ siteid = 251
 
 [script]
 dependencies = [ "Camera" ]
+optional_dependencies = [ "Editor" ]

--- a/main.as
+++ b/main.as
@@ -5,6 +5,7 @@ namespace State
 	bool MenuButtonDown = false;
 
 	int CurrentRaceTime = 0;
+
 }
 
 void OnEditorLeave()
@@ -133,7 +134,7 @@ void Main()
 
 		bool entityStateAvailable = scriptPlayer.IsEntityStateAvailable;
 		int startTime = scriptPlayer.StartTime;
-		State::CurrentRaceTime = scriptPlayer.CurrentRaceTime;
+		State::CurrentRaceTime = GetApp().Network.PlaygroundClientScriptAPI.GameTime - scriptPlayer.StartTime;
 
 #else
 		// Get player information in Maniaplanet


### PR DESCRIPTION
`State::CurrentRaceTime = GetApp().Network.PlaygroundClientScriptAPI.GameTime - scriptPlayer.StartTime;`
is the line that fixes current race time if you want just that. (Editor Trails has been broken for a while, not sure why CurrentRaceTime changed behavior.)

The rest of this PR is adding support for drawing trails via E++'s newly exposed draw lines and quads module. A screenshot of what it looks like is included below.

I don't really mind if this PR is accepted or not, it was mostly for me to test that the draw API worked correctly.
But if you would like it to be added I'm happy to do a little polish.

![image](https://github.com/user-attachments/assets/dcf2fee2-ace4-4dc2-902e-0c630ce31a07)
